### PR TITLE
Fixed moving 'down' while flying in creative mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>io.totemo</groupId>
 	<name>WingCommander</name>
 	<artifactId>${project.name}</artifactId>
-	<version>1.6.0</version>
+	<version>1.6.1</version>
 	<packaging>jar</packaging>
 	<description>Enables powered flight with elytra.</description>
 	<url>https://github.com/totemo/${project.name}</url>

--- a/src/io/totemo/wingcommander/PlayerState.java
+++ b/src/io/totemo/wingcommander/PlayerState.java
@@ -1,6 +1,7 @@
 package io.totemo.wingcommander;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.boss.BarColor;
@@ -54,7 +55,7 @@ public class PlayerState {
 
         // If a player loses glide in flight, let them glide again in the air
         // by pressing crouch.
-        if (_player.isSneaking() && WingCommander.isFlightCapable(_player) && !_player.isOnGround()) {
+        if (_player.isSneaking() && WingCommander.isFlightCapable(_player) && !_player.isOnGround() && !_player.isFlying()) {
             accelerate(WingCommander.CONFIG.ACCELERATION_LOOK);
         }
 


### PR DESCRIPTION
Taught Wing Commander that the crouch key should not initiate flight if a player is already in creative fly mode.
